### PR TITLE
fix version number to match ChangeLog file: 1.8.0

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,6 +1,6 @@
 AC_PREREQ(2.60)
 
-AC_INIT([osslsigncode], [1.7.1], [pallansson@gmail.com])
+AC_INIT([osslsigncode], [1.8.0], [pallansson@gmail.com])
 AC_CONFIG_AUX_DIR([.])
 AC_CONFIG_HEADERS([config.h])
 AM_INIT_AUTOMAKE


### PR DESCRIPTION
Please increase the version number to 1.8.0, as stated in the ChangeLog file.

My problem: I need PKCS#11 based hardware tokens, but Ubuntu delivers version 1.7.1. The current code, according to it's version number, seems to be in the same version, but in fact it is not. 1.7.1 is missing hardware tokens, 1.8.0 supports them. So it makes sense to increase the version number, and hopefully, Ubuntu will also update the package soon…

Anyway, I'll create debian packages on my own, you may get them from https://repository.mrw.sh, see https://mrw.sh for more details.

If you are interested, why I need HSM, see my blog: https://marc.wäckerlin.ch/computer/suisseid-as-code-signing-hsm